### PR TITLE
Adding -p flag to specify individual paths to organize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build: ## Build the executable. Example: make build
 .PHONY: build
 
 clean: ## Clean up the workspace. Example: make clean
-	rm -rf .goio *.pprof profile*
+	rm -rf goio *.pprof profile*
 .PHONY: clean
 
 help: ## Print this help. Example: make help

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 A customizable imports organizer for the Go programming language
 
 * [Summary](#summary)
-* [Installation](#installation)
+* [Command Line Tool](#command-line-tool)
+* [CI/CD Integration](#ci-cd-integration)
 * [Configuration](#configuration)
+* [Profiling](#profiling)
 
 # <a name='summary'></a>Summary
 `goio` is a fully customizable Go imports organizer. The configuration
@@ -12,23 +14,33 @@ is project based and is stored in a `goio.yaml` file in the root of your
 module's project folder alongside the `go.mod` file. For consistency
 the `goio.yaml` file should be committed to your projects vcs.
 
-# <a name='installation'></a>Installation
 
-## Command Line Tool
 
+# <a name='command-line-tool'></a>Command Line Tool
+
+## Installation
 ```
   $ go install github.com/go-imports-organizer/goio@latest
 ```
 
-## Go project configuration
+## Usage
+```
+Usage of goio:
+  -p value
+    	path to a file or directory to organize, use multiple times for multiple files
+  -l	list files that need to be organized (no changes made)
+  -v	print version and exit
 
-### Example scripts/tools.go file
+```
+# <a name='ci-cd-configuration'></a>CI/CD Configuration
+
+## Example scripts/tools.go file
 This file will ensure that the `github.com/go-imports-organizer/goio` repo is vendored into your project.
 ```
 //go:build tools
 // +build tools
 
-package hack
+package scripts
 
 // Add tools that scripts depend on here, to ensure they are vendored.
 import (
@@ -37,7 +49,7 @@ import (
 
 ```
 
-### Example scripts/verify-imports.sh script
+## Example scripts/verify-imports.sh script
 This file will check if there are any go files that need to be formatted. If there are, it will print a list of them, and exit with status one (1), otherwise it will exit with status zero (0). Make sure that you make the file executable with `chmod +x scripts/verify-imports.sh`.
 ```
 #!/bin/bash
@@ -51,7 +63,7 @@ if [[ -n "${bad_files}" ]]; then
 fi
 ```
 
-### Example Makefile sections
+## Example Makefile sections
 ```
 imports: ## Organize imports in go files using goio. Example: make imports
 	go run ./vendor/github.com/go-imports-organizer/goio
@@ -62,46 +74,67 @@ verify-imports: ## Run import verifications. Example: make verify-imports
 .PHONY: verify-imports
 ```
 
-# <a name='Configuration'></a>Configuration
+# <a name='configuration-file'></a>Configuration File
 The `goio.yaml` configuration file is a well formatted yaml file.
 
-### Excludes
+## Excludes
 An array of Exclude definitions.
 
 Each Exclude definition is a rule that tells `goio` which files and folders to ignore while looking for Go files that it should organize the imports of. The default configuration file ignores the `.git` directory and the `vendor` directory. The more files and folders that you can ignore at this stage the faster `goio` will run.
 
-#### RegExp
+### RegExp
 A string, valid values are any valid Go regular expression.
 
 A well formatted Regular Expression that is used to match against. Be as specific as possible.
 
-#### MatchType
+### MatchType
 A string, valid values are `[name, path]`.
 
 Lets `goio` know whether to match agains the files `name` or the files `path` relative to the modules root directory _(where the go.mod file is located)_.
 
-### Groups
+## Groups
 An array of Group definitions
 
 Each group definition is a rule that tells `goio` how you would like the `imports` in your Go files organized. Each definition represents a block of import statements, describing how to identify the items that it should contain. Group blocks are displayed in **the order that they appear in the array**.
 
-#### Description
+### Description
 A string, valid values are any valid string value
 
 A friendly name to identify the definition by instead of trying to decipher the regular expression each time to remember what it does.
 
-#### RegExp
+### RegExp
 An array of strings, valid values are any valid Go regular expression.
 
 A well formatted Regular Expression that is used to match against. Be as specific as possible.
 
-**Note:**
+**NOTE:**
 
 There is one keyword that is available for the RegExp value that is a special keyword, it is `%{module}%`. This keyword automatically creates a regular expression that matches the current module name as defined by the go.mod file. To ensure that it captures the correct imports you should always set the `MatchOrder` to `0` for this definition.
 
-#### MatchOrder
+### MatchOrder
 An integer, valid values are -n...n
 
 Tells `goio` which order the definitions should be matched against in. Lower numbers are first, higher numbers are last.
 
 It is important to ensure the correct `matchorder` is used, expecially if any of your `regexp` have any kind of overlap, such as having a module name of `github.com/example/mymodule` and a group definition for `github.com/example`. You would want to make sure that your `module` definition was matched first or those imports would get rolled into the `github.com/example` one because it is less specific.
+
+**NOTE**
+The recommended Match Order to avoid the above scenario is:
+ - module *(should always be first)*
+ - custom groups *(ordered most specific to least specific)*
+ - standard *(should be second to last)*
+ - other *(should be last)*
+
+# <a name='profiling'></a>Profiling
+Profiling via the `pprof` tools is already configured within the application and can be enabled using the following methods.
+## CPU Profiling
+You can enable CPU profiling by setting the `CPUPROFILE` environment variable to the name of the file that the profiling information should be written to.
+```
+  $ CPUPROFILE=cpu.pprof goio
+```
+
+## Memory Profiling
+You can enable MEMORY profiling by setting the `MEMPROFILE` environment variable to the name of the file that the profiling information should be written to.
+```
+  $ MEMPROFILE=mem.pprof goio
+```

--- a/examples/openshift_kubernetes.yaml
+++ b/examples/openshift_kubernetes.yaml
@@ -7,7 +7,7 @@ excludes:
     regexp: ^vendor$
 groups:
   - description: standard
-    matchorder: 0
+    matchorder: 3
     regexp:
       - ^[a-zA-Z0-9\/]+$
   - description: kubernetes
@@ -15,7 +15,7 @@ groups:
     regexp:
       - ^k8s\.io
   - description: openshift
-    matchorder: 3
+    matchorder: 2
     regexp:
       - ^github\.com\/openshift
   - description: other
@@ -23,6 +23,6 @@ groups:
     regexp:
       - '[a-zA-Z0-9]+\.[a-zA-Z0-9]+/'
   - description: module
-    matchorder: 2
+    matchorder: 0
     regexp:
       - "%{module}%"

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -17,37 +17,57 @@ package v1alpha1
 
 import (
 	"regexp"
+	"strings"
 )
 
+// RegExpMatcher
 type RegExpMatcher struct {
-	Bucket string
-	RegExp *regexp.Regexp
+	Bucket string         `yaml:"bucket"`
+	RegExp *regexp.Regexp `yaml:"regexp"`
 }
 
 const (
-	ExcludeMatchTypeName         string = "name"
+	// ExcludeMatchTypeName tells an Exclude to match against the file or folder name
+	ExcludeMatchTypeName string = "name"
+	// ExcludeMatchTypeRelativePath tells an Exclude to match against the file or folder path
 	ExcludeMatchTypeRelativePath string = "path"
 )
 
+// Exclude defines a file or folder that should be excluded from being organized
 type Exclude struct {
-	MatchType string
-	RegExp    string
+	// MatchType defines whether the file name or file path should be matched against
+	MatchType string `yaml:"matchtype"`
+	// RegExp is the Regular Expression that is used to match against
+	RegExp string `yaml:"regexp"`
 }
 
+// Group defines a block of imports
 type Group struct {
-	MatchOrder  int
-	Description string
-	RegExp      []string
+	// MatchOrder is the order is which the Regular Expression will be matched
+	// against an import to determine its group
+	MatchOrder int `yaml:"matchorder"`
+	// Description is a friendly name for the group
+	Description string `yaml:"description"`
+	// RegExp is the Regular Expression that is used to match against
+	RegExp []string `yaml:"regexp"`
 }
 
-const (
-	GroupMatchValueStandard          string = "standard"
-	GroupMatchValueModule            string = "module"
-	GroupMatchValueOther             string = "other"
-	GroupMatchValueModulePlaceholder string = "%{module}%"
-)
-
+// Config is the configuration for the Go Imports Organizer
 type Config struct {
-	Excludes []Exclude
-	Groups   []Group
+	// Excludes is a slice of Exclude objects
+	Excludes []Exclude `yaml:"excludes"`
+	// Groups is a slice of Group objects
+	Groups []Group `yaml:"groups"`
+}
+
+// PathListFlags is a type that can store Path objects that are supplied via the -p flag
+type PathListFlags []string
+
+func (i *PathListFlags) String() string {
+	return strings.Join(*i, ",")
+}
+
+func (i *PathListFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	v1alpha1 "github.com/go-imports-organizer/goio/pkg/api/v1alpha1"
 )
 
+// Load loads the configuration from a yaml file
 func Load(file string) (v1alpha1.Config, error) {
 	var configFile []byte
 	var err error

--- a/pkg/excludes/excludes.go
+++ b/pkg/excludes/excludes.go
@@ -7,6 +7,8 @@ import (
 	v1alpha1 "github.com/go-imports-organizer/goio/pkg/api/v1alpha1"
 )
 
+// Build assembles the Regular Expressions that are used to exclude files and folders
+// based on their name or path
 func Build(excludes []v1alpha1.Exclude) (*regexp.Regexp, *regexp.Regexp) {
 	var excludeByPath []string
 	var excludeByName []string

--- a/pkg/groups/groups.go
+++ b/pkg/groups/groups.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-imports-organizer/goio/pkg/sorter"
 )
 
+// Build asembles the RegExpMatchers that are used to group imports and the
+// array that defines the display order for the groups in the import block
 func Build(groups []v1alpha1.Group, goModuleName string) ([]v1alpha1.RegExpMatcher, []string) {
 	groupRegExpMatchers := []v1alpha1.RegExpMatcher{}
 	displayOrder := []string{}

--- a/pkg/module/find.go
+++ b/pkg/module/find.go
@@ -23,6 +23,8 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+// FindGoModuleNameAndPath finds the current Go modules name (via the go.mod file)
+// and path (location of the go.mod file on the filesystem)
 func FindGoModuleNameAndPath(path string) (string, string, error) {
 	for path != "." {
 		if _, err := os.Stat(path); err != nil {

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -21,12 +21,14 @@ import (
 	v1alpha1 "github.com/go-imports-organizer/goio/pkg/api/v1alpha1"
 )
 
+// SortImportsByPathValue sorts a slice of ImportSpecs using their Path.Value
 type SortImportsByPathValue []ast.ImportSpec
 
 func (a SortImportsByPathValue) Len() int           { return len(a) }
 func (a SortImportsByPathValue) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a SortImportsByPathValue) Less(i, j int) bool { return a[i].Path.Value < a[j].Path.Value }
 
+// SortGroupsByMatchOrder sorts a slice of Group objects using their MatchOrder
 type SortGroupsByMatchOrder []v1alpha1.Group
 
 func (a SortGroupsByMatchOrder) Len() int           { return len(a) }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,6 +6,7 @@ import (
 
 var Version string
 
+// Get returns the applications Version based on its build information
 func Get() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		return info.Main.Version


### PR DESCRIPTION
Adding -f flag to specify individual files to run on, can be used multiple times to specify multiple files